### PR TITLE
调整小米icon上传接口为https://api.xmpush.xiaomi.com/media/upload/image

### DIFF
--- a/manufacturer/xm/xm_service.go
+++ b/manufacturer/xm/xm_service.go
@@ -9,41 +9,37 @@ import (
 	"github.com/GetuiLaboratory/getui-3rd-push-utils-go/util"
 )
 
-const UPLOAD_ICON_URL string = "https://api.xmpush.xiaomi.com/media/upload/smallIcon"
 const UPLOAD_PIC_URL string = "https://api.xmpush.xiaomi.com/media/upload/image"
 
 func UploadPic(file string, isIcon bool, conf config.Conf) result.Result {
-	var uploadUrl string
 	var reqParams map[string]string = make(map[string]string)
 	if isIcon {
 		if x, found := util.Get(consts.BIG_KEY_ICON+consts.MANUFACTURER_XM, file); found {
 			return result.Success(x)
 		}
-		uploadUrl = UPLOAD_ICON_URL
+		reqParams["is_icon"] = "true"
 	} else {
 		if x, found := util.Get(consts.BIG_KEY_PIC+consts.MANUFACTURER_XM, file); found {
 			return result.Success(x)
 		}
-		uploadUrl = UPLOAD_PIC_URL
-		reqParams["is_global"] = "false"
 		reqParams["is_icon"] = "false"
 	}
 
 	var headers map[string]string = make(map[string]string)
 	headers["Authorization"] = "key=" + conf.XmAppSecret
-
+	reqParams["is_global"] = "false"
 	files := []util.UploadFile{
 		{Name: "file", Filepath: file},
 	}
 
-	var uploadResult = util.PostFile(uploadUrl, reqParams, files, headers)
+	var uploadResult = util.PostFile(UPLOAD_PIC_URL, reqParams, files, headers)
 
 	var resultMap map[string]interface{}
 	json.Unmarshal([]byte(uploadResult), &resultMap)
 	if util.IsEqual(resultMap["code"].(float64), 0) {
 		var fileUrl string
 		if isIcon {
-			fileUrl = resultMap["data"].(map[string]interface{})["small_icon_url"].(string)
+			fileUrl = resultMap["data"].(map[string]interface{})["icon_url"].(string)
 			util.Set(consts.BIG_KEY_ICON+consts.MANUFACTURER_XM, file, fileUrl, -1)
 		} else {
 			fileUrl = resultMap["data"].(map[string]interface{})["pic_url"].(string)


### PR DESCRIPTION
为了和小米官网icon上传和推送接口相匹配，调整小米icon上传接口为https://api.xmpush.xiaomi.com/media/upload/image，该icon大小为120*120。之前使用的接口是https://api.xmpush.xiaomi.com/media/upload/smallIcon，smallIcon的大小为75*75